### PR TITLE
Add deeper nested relations for includes

### DIFF
--- a/src/Support/Includes.php
+++ b/src/Support/Includes.php
@@ -46,7 +46,7 @@ final class Includes
         return $this->rememberIncludes($request, $prefix, function () use ($request, $prefix): Collection {
             return $this->all($request)
                 ->when($prefix !== '')
-                ->filter(fn (string $include): bool => str_starts_with($include, $prefix))
+                ->filter(fn (string $include): bool => str_contains($include, $prefix))
                 ->map(fn ($include): string => (string) Str::of($include)->after($prefix)->before('.'))
                 ->uniqueStrict()
                 ->values();


### PR DESCRIPTION
First things first: Thanks for the great package and your effort! 

I ran into some limitations to load deeper nested relations. It only consider relations until the second level, all further relations are filtered out. 

This MR change the filter criteria of the `forPrefix` method in `Includes.php`