### PR TITLE
[Issue-69] Adjust relation call for nulled resources

### DIFF
--- a/src/Concerns/Relationships.php
+++ b/src/Concerns/Relationships.php
@@ -143,7 +143,7 @@ trait Relationships
                 $value => self::guessRelationshipResource($value, $this),
             ])
             ->map(fn (string $class, string $relation): Closure => function () use ($class, $relation): JsonApiResource|JsonApiResourceCollection {
-                return with($this->resource->{$relation}, function (mixed $resource) use ($class): JsonApiResource|JsonApiResourceCollection {
+                return with($this->resource?->{$relation}, function (mixed $resource) use ($class): JsonApiResource|JsonApiResourceCollection {
                     if ($resource instanceof Traversable || (is_array($resource) && ! Arr::isAssoc($resource))) {
                         return $class::collection($resource);
                     }


### PR DESCRIPTION
When requesting a nested include such as `destination.location` for a `stop` resource, if the `stop` does not have a `destination` attached, the request currently fails with an error. This behavior is inconsistent with the JSON:API specification, which requires that missing nullable relationships should return `null`.

#### Solution:
Adjusted the `resolveRelationships` method in the `Relationships` trait to handle cases where a requested relationship is missing.

#### Example Behavior After Fix:
Requesting `destination.location` for a `stop` without a `destination` will return:
```json
"relationships": {
    "destination": {
        "data": null
    }
}
```

#### Linked Issue: https://github.com/timacdonald/json-api/issues/69
